### PR TITLE
Expose the acouchbase module so it is accessible from pip installations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,6 +125,7 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules"],
 
     packages = [
+        'acouchbase',
         'couchbase',
         'couchbase.views',
         'couchbase.iops',


### PR DESCRIPTION
When installing the library through pip, the acouchbase module is not available, unlike txcouchbase and gcouchbase.
